### PR TITLE
switch to new hspec option

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -40,7 +40,7 @@ in
     '';
   })).overrideAttrs (old: {
   # Don’t allow focused tests to pass CI
-  HSPEC_OPTIONS = "--fail-on-focused";
+  HSPEC_OPTIONS = "--fail-on=focused";
 
   disallowedReferences = badReferences;
 


### PR DESCRIPTION
The new version of hspec uses --fail-on=ITEMS instead of individual flags: https://hspec.github.io/options.html

Would actually consider switching to --strict as well